### PR TITLE
Fix login screen z-index blocking Netlify Identity widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -750,7 +750,7 @@
       position: fixed;
       inset: 0;
       background: var(--void);
-      z-index: 10000;
+      z-index: 100;
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
#loginScreen z-index 10000 was covering the widget iframe (~z-index 99), making the modal invisible when Login was clicked.

https://claude.ai/code/session_01DQpT3Pi3sWcs43gRyCfs52